### PR TITLE
ItemOrder creation and Merchant deletion

### DIFF
--- a/app/controllers/merchants_controller.rb
+++ b/app/controllers/merchants_controller.rb
@@ -27,7 +27,6 @@ class MerchantsController <ApplicationController
   end
 
   def destroy
-    Item.delete(Item.where(merchant_id: params[:id]))
     Merchant.destroy(params[:id])
     redirect_to '/merchants'
   end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -8,8 +8,7 @@ class OrdersController < ApplicationController
     order = Order.new(order_params)
     if order.save
       cart = Cart.new(session[:cart])
-      total = cart.order_total
-      cart.create_item_orders(order, total)
+      order.create_item_orders(cart)
       redirect_to "/orders/#{order.id}"
     else
       flash[:error] = "Please fill in all the fields"

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -7,6 +7,14 @@ class OrdersController < ApplicationController
   def create
     order = Order.new(order_params)
     if order.save
+      cart = Cart.new(session[:cart])
+      total = cart.order_total
+      cart.contents.each do |item, qty|
+        ItemOrder.create(order_id: order.id,
+                        item_id: Item.find(item).id,
+                        quantity: qty,
+                        total_cost: total)
+      end
       redirect_to "/orders/#{order.id}"
     else
       flash[:error] = "Please fill in all the fields"

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -9,12 +9,7 @@ class OrdersController < ApplicationController
     if order.save
       cart = Cart.new(session[:cart])
       total = cart.order_total
-      cart.contents.each do |item, qty|
-        ItemOrder.create(order_id: order.id,
-                        item_id: Item.find(item).id,
-                        quantity: qty,
-                        total_cost: total)
-      end
+      cart.create_item_orders(order, total)
       redirect_to "/orders/#{order.id}"
     else
       flash[:error] = "Please fill in all the fields"

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -24,7 +24,15 @@ class Cart
   end
 
   def order_total
-    @contents.map { |id, num| subtotal(id) }.sum
+    @contents.map { |id, qty| subtotal(id) }.sum
   end
 
+  def create_item_orders(order, total)
+    @contents.each do |item, qty|
+      ItemOrder.create(order_id: order.id,
+                      item_id: Item.find(item).id,
+                      quantity: qty,
+                      total_cost: total)
+    end
+  end
 end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -26,13 +26,4 @@ class Cart
   def order_total
     @contents.map { |id, qty| subtotal(id) }.sum
   end
-
-  def create_item_orders(order, total)
-    @contents.each do |item, qty|
-      ItemOrder.create(order_id: order.id,
-                      item_id: Item.find(item).id,
-                      quantity: qty,
-                      total_cost: total)
-    end
-  end
 end

--- a/app/models/item_order.rb
+++ b/app/models/item_order.rb
@@ -1,4 +1,9 @@
 class ItemOrder < ApplicationRecord
   belongs_to :order
   belongs_to :item
+
+  validates_presence_of :item_id
+  validates_presence_of :order_id
+  validates_presence_of :quantity
+  validates_presence_of :total_cost
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -8,6 +8,8 @@ class Merchant <ApplicationRecord
                         :zip
 
   def has_orders?
-    
+    ItemOrder.joins(:item)
+    .where("items.merchant_id = #{self.id}")
+    .count > 0
   end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,10 +1,13 @@
 class Merchant <ApplicationRecord
-  has_many :items
-  
+  has_many :items, dependent: :destroy
+
   validates_presence_of :name,
                         :address,
                         :city,
                         :state,
                         :zip
 
+  def has_orders?
+    
+  end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -2,4 +2,14 @@ class Order < ApplicationRecord
   has_many :item_orders
   has_many :items, through: :item_orders
   validates_presence_of :name, :address, :city, :state, :zip
+
+  def create_item_orders(cart)
+    total = cart.order_total
+    cart.contents.each do |item, qty|
+      ItemOrder.create(order_id: self.id,
+                      item_id: Item.find(item).id,
+                      quantity: qty,
+                      total_cost: total)
+    end
+  end
 end

--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -2,7 +2,8 @@
 <p class="address"><%= @merchant.address %></p>
 <p class="address"><%= @merchant.city %>, <%= @merchant.state %> <%= @merchant.zip %></p>
 
-<ul><%= link_to "All #{@merchant.name} Items", "/merchants/#{@merchant.id}/items" %></ul>
-<ul><%= link_to "Update Merchant", "/merchants/#{@merchant.id}/edit", class: "edit-btn"%></ul>
-<ul><%= link_to "Delete Merchant", "/merchants/#{@merchant.id}", method: :delete, class: "delete-btn" %>
-</ul>
+<p><%= link_to "All #{@merchant.name} Items", "/merchants/#{@merchant.id}/items" %></p>
+<p><%= link_to "Update Merchant", "/merchants/#{@merchant.id}/edit", class: "edit-btn"%></p>
+<% unless @merchant.has_orders? %>
+  <p><%= link_to "Delete Merchant", "/merchants/#{@merchant.id}", method: :delete, class: "delete-btn" %></p>
+<% end %>

--- a/spec/features/item_orders/new_spec.rb
+++ b/spec/features/item_orders/new_spec.rb
@@ -1,7 +1,45 @@
 require 'rails_helper'
 
 describe 'User fills in order form and clicks Place Order' do
-  it "text" do
+  it "can create item_orders from contents" do
+    dog_shop = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80210)
+    pull_toy = dog_shop.items.create(name: "Pull Toy", description: "Great pull toy!", price: 10, image: "http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg", inventory: 32)
+    dog_bone = dog_shop.items.create(name: "Dog Bone", description: "They'll love it!", price: 21, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", active?:false, inventory: 21)
 
+    visit "/items/#{pull_toy.id}"
+    click_link 'Add to Cart'
+    visit "/items/#{dog_bone.id}"
+    click_link 'Add to Cart'
+    visit "/items/#{dog_bone.id}"
+    click_link 'Add to Cart'
+    visit '/cart'
+    click_link 'Checkout'
+
+    name = "Sal"
+    address = '123 Kindalikeapizza Dr.'
+    city = "Denver"
+    state = "CO"
+    zip = 80204
+
+    fill_in :name, with: name
+    fill_in :address, with: address
+    fill_in :city, with: city
+    fill_in :state, with: state
+    fill_in :zip, with: zip
+
+    click_button "Place Order"
+
+    order = Order.last
+    last_2 = ItemOrder.last(2)
+
+    expect(last_2[0].order_id).to eq(order.id)
+    expect(last_2[0].item_id).to eq(pull_toy.id)
+    expect(last_2[0].quantity).to eq(1)
+    expect(last_2[0].total_cost).to eq(52)
+
+    expect(last_2[1].order_id).to eq(order.id)
+    expect(last_2[1].item_id).to eq(dog_bone.id)
+    expect(last_2[1].quantity).to eq(2)
+    expect(last_2[1].total_cost).to eq(52)
   end
 end

--- a/spec/features/item_orders/new_spec.rb
+++ b/spec/features/item_orders/new_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+describe 'User fills in order form and clicks Place Order' do
+  it "text" do
+
+  end
+end

--- a/spec/features/merchants/destroy_spec.rb
+++ b/spec/features/merchants/destroy_spec.rb
@@ -1,32 +1,53 @@
 require 'rails_helper'
 
 RSpec.describe "As a visitor" do
-  describe "When I visit a merchant show page" do
-    it "I can delete a merchant" do
-      bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Richmond', state: 'VA', zip: 80203)
+  describe "When a merchant has no orders" do
+    describe "When I visit a merchant show page" do
+      it "I can delete a merchant" do
+        bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Richmond', state: 'VA', zip: 80203)
 
-      visit "merchants/#{bike_shop.id}"
+        visit "merchants/#{bike_shop.id}"
 
-      click_on "Delete Merchant"
+        click_on "Delete Merchant"
 
-      expect(current_path).to eq('/merchants')
-      expect(page).to_not have_content("Brian's Bike Shop")
+        expect(current_path).to eq('/merchants')
+        expect(page).to_not have_content("Brian's Bike Shop")
+      end
+
+      it "I can delete a merchant that has items" do
+        bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+        chain = bike_shop.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
+
+        visit '/merchants'
+        expect(page).to have_css("#merchant-#{bike_shop.id}")
+
+        visit "merchants/#{bike_shop.id}"
+
+        click_on "Delete Merchant"
+
+        expect(current_path).to eq('/merchants')
+        expect(page).to_not have_content("Brian's Bike Shop")
+        expect(page).to_not have_css("#merchant-#{bike_shop.id}")
+      end
     end
+  end
 
-    it "I can delete a merchant that has items" do
-      bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
-      chain = bike_shop.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
+  describe "When a merchant has orders" do
+    it "I cannot delete the merchant because there is no delete button" do
+      dog_shop = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80210)
+      dog_bone = dog_shop.items.create(name: "Dog Bone", description: "They'll love it!", price: 21, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", active?:false, inventory: 21)
 
-      visit '/merchants'
-      expect(page).to have_css("#merchant-#{bike_shop.id}")
+      visit "/merchants/#{dog_shop.id}"
 
-      visit "merchants/#{bike_shop.id}"
+      expect(page).to have_link('Delete Merchant')
 
-      click_on "Delete Merchant"
+      cart = Cart.new( {"#{dog_bone.id}" => "1"} )
+      order = Order.create(name: "Bob", address: "234 A st.", city: "Torrance", state: "CA", zip: 90505)
+      order.create_item_orders(cart)
 
-      expect(current_path).to eq('/merchants')
-      expect(page).to_not have_content("Brian's Bike Shop")
-      expect(page).to_not have_css("#merchant-#{bike_shop.id}")
+      visit "/merchants/#{dog_shop.id}"
+
+      expect(page).to_not have_link('Delete Merchant')
     end
   end
 end

--- a/spec/features/merchants/destroy_spec.rb
+++ b/spec/features/merchants/destroy_spec.rb
@@ -28,6 +28,9 @@ RSpec.describe "As a visitor" do
         expect(current_path).to eq('/merchants')
         expect(page).to_not have_content("Brian's Bike Shop")
         expect(page).to_not have_css("#merchant-#{bike_shop.id}")
+
+        visit "/items"
+        expect(page).to_not have_css("#item-#{chain.id}")
       end
     end
   end

--- a/spec/models/item_order_spec.rb
+++ b/spec/models/item_order_spec.rb
@@ -7,9 +7,9 @@ describe ItemOrder do
   end
 
   describe 'validations' do
-    it { should validate_presence_of :item_id}
-    it { should validate_presence_of :order_id}
-    it { should validate_presence_of :quantity}
-    it { should validate_presence_of :total_cost}
+    it { should validate_presence_of :item_id }
+    it { should validate_presence_of :order_id }
+    it { should validate_presence_of :quantity }
+    it { should validate_presence_of :total_cost }
   end
 end

--- a/spec/models/item_order_spec.rb
+++ b/spec/models/item_order_spec.rb
@@ -6,5 +6,10 @@ describe ItemOrder do
     it { should belong_to :item}
   end
 
-  # validations ?
+  describe 'validations' do
+    it { should validate_presence_of :item_id}
+    it { should validate_presence_of :order_id}
+    it { should validate_presence_of :quantity}
+    it { should validate_presence_of :total_cost}
+  end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -24,7 +24,7 @@ describe Merchant, type: :model do
       order = Order.create(name: "Bob", address: "234 A st.", city: "Torrance", state: "CA", zip: 90505)
       order.create_item_orders(cart)
 
-      expect (dog_shop.has_orders?).to eq(true)
+      expect(dog_shop.has_orders?).to eq(true)
     end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -12,4 +12,19 @@ describe Merchant, type: :model do
   describe "relationships" do
     it {should have_many :items}
   end
+
+  describe 'instance methods' do
+    it '#has_orders?' do
+      dog_shop = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80210)
+      dog_bone = dog_shop.items.create(name: "Dog Bone", description: "They'll love it!", price: 21, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", active?:false, inventory: 21)
+
+      expect(dog_shop.has_orders?).to eq(false)
+
+      cart = Cart.new( {"#{dog_bone.id}" => "1"} )
+      order = Order.create(name: "Bob", address: "234 A st.", city: "Torrance", state: "CA", zip: 90505)
+      order.create_item_orders(cart)
+
+      expect (dog_shop.has_orders?).to eq(true)
+    end
+  end
 end


### PR DESCRIPTION
ItemOrders
- Add test to verify that ItemOrder records are created in conjunction with Order when user clicks 'Place Order' on new order page
- Logic for ItemOrder creation lives in Order model since it is related to the creation of an order

Merchant Deletion
- Add dependents: :destroy to Merchant model to also delete its items
- Use active record query to check if a merchant has items in item_orders table
    - If merchant has orders, the 'Delete Merchant' button will not appear on that merchant's show page.
    - If a merchant has no items in item_orders, clicking 'Delete Merchant' will delete that merchant and all of their items